### PR TITLE
Adds error message to SendError

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -41,6 +41,6 @@ pub enum WsError {
     InvalidMessageReceived(String),
     ConnectionError,
     InvalidMessage,
-    SendError,
+    SendError(String),
     NotConnected,
 }


### PR DESCRIPTION
Updates the `SendError` variant to include an error message,
providing more context when send operations fail.
